### PR TITLE
Upgrade cryptography to version 3.3.2

### DIFF
--- a/sld-api-backend/requirements.txt
+++ b/sld-api-backend/requirements.txt
@@ -18,7 +18,7 @@ click-didyoumean==0.0.3
 click-repl==0.1.6
 configobj==5.0.6
 croniter==1.0.7
-cryptography==3.2.1
+cryptography==3.3.2
 dnspython==2.0.0
 docutils==0.16
 ecdsa==0.14.1


### PR DESCRIPTION
### Cryptography vulnerability found in sld-api-backend/requirements.txt 

**Remediation**
Upgrade cryptography to version 3.3.2 
**Details**
GHSA-rhm9-p9w5-fwm7
moderate severity
Vulnerable versions: >= 3.1, < 3.3.2
Patched version: 3.3.2
**Impact**
When certain sequences of update() calls with large values (multiple GBs) for symetric encryption or decryption occur, it's possible for an integer overflow to happen, leading to mishandling of buffers.

**Patches**
This is patched in version 3.3.2 and newer.

**References**
pyca/cryptography#5615

