### PR TITLE
🐛 fix: ansible-runner vulnerable to shell command injection

### DIFF
--- a/.github/workflows/sld-api-docker-image.yml
+++ b/.github/workflows/sld-api-docker-image.yml
@@ -24,11 +24,11 @@ jobs:
 
     - name: Build the Docker image with tag
       working-directory: ./sld-api-backend
-      run: docker build . --file Dockerfile --tag ${{ secrets.DOCKER_USERNAME }}/sld-api:2.8.0
+      run: docker build . --file Dockerfile --tag ${{ secrets.DOCKER_USERNAME }}/sld-api:2.8.1
       
     - name: Docker Push with tag
       #if: github.event.pull_request.merged == true
-      run: docker push ${{ secrets.DOCKER_USERNAME }}/sld-api:2.8.0
+      run: docker push ${{ secrets.DOCKER_USERNAME }}/sld-api:2.8.1
 
     - name: Build the Docker image
       working-directory: ./sld-api-backend

--- a/play-with-sld/kubernetes/k8s/kustomization.yaml
+++ b/play-with-sld/kubernetes/k8s/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 commonLabels:
   app: stack-lifecycle-deploy
   environment: play
-  version: 2.11.0
+  version: 2.12.1
 
 resources:
  - mysql-service.yml

--- a/sld-api-backend/requirements.txt
+++ b/sld-api-backend/requirements.txt
@@ -4,7 +4,7 @@ amqp==5.1.0
 ansible==5.5.0
 ansible-base==2.10.17
 ansible-core==2.12.4
-ansible-runner==1.4.7
+ansible-runner==2.2.1
 anyio==3.5.0
 asgiref==3.5.0
 async-timeout==4.0.2


### PR DESCRIPTION
A flaw was found in ansible-runner. An improper escaping of the shell command, while calling the ansible_runner.interface.run_command, can lead to parameters getting executed as host's shell command. A developer could unintentionally write code that gets executed in the host rather than the virtual environment.